### PR TITLE
Remove an inlier polygon point in the extrusion_mount_2D(). The tensi…

### DIFF
--- a/PushPullFeeder.scad
+++ b/PushPullFeeder.scad
@@ -1776,6 +1776,7 @@ module extrusion_mount_2D() {
     left_edge_y=extrusion_mount_y-extrusion_mount_h/2+wall;
     left_edge_x=reel_x
         +sqrt(pow(base_begin_r, 2) - pow(left_edge_y-reel_y, 2));
+    
     extrusion_mount_contour = [
         [tape_inset_begin+e, -base_height+e],
         each arc(

--- a/PushPullFeeder.scad
+++ b/PushPullFeeder.scad
@@ -1776,7 +1776,6 @@ module extrusion_mount_2D() {
     left_edge_y=extrusion_mount_y-extrusion_mount_h/2+wall;
     left_edge_x=reel_x
         +sqrt(pow(base_begin_r, 2) - pow(left_edge_y-reel_y, 2));
-
     extrusion_mount_contour = [
         [tape_inset_begin+e, -base_height+e],
         each arc(
@@ -1797,8 +1796,6 @@ module extrusion_mount_2D() {
         [extrusion_mount_x-extrusion_mount_w/2+extrusion_mount_tension/2, 
             hanger_y+hanger_dy],
         -hanger_angle),
-        [extrusion_mount_x-extrusion_mount_w/2,
-            extrusion_mount_y+extrusion_mount_h/2],
         each [ for (xx = [0.5:extrusion_mount_w/extrusion_mount_unit]) 
             each arc(
             [extrusion_mount_x-extrusion_mount_w/2 + xx*extrusion_mount_unit

--- a/PushPullFeeder.scad
+++ b/PushPullFeeder.scad
@@ -1776,7 +1776,7 @@ module extrusion_mount_2D() {
     left_edge_y=extrusion_mount_y-extrusion_mount_h/2+wall;
     left_edge_x=reel_x
         +sqrt(pow(base_begin_r, 2) - pow(left_edge_y-reel_y, 2));
-    
+
     extrusion_mount_contour = [
         [tape_inset_begin+e, -base_height+e],
         each arc(


### PR DESCRIPTION
# Description

Remove an inlier polygon point in the extrusion_mount_2D(). See the issue it created in a newer OpenSCAD version:

https://github.com/openscad/openscad/issues/4022#issuecomment-998419042

![image](https://user-images.githubusercontent.com/9963310/147651816-9e4ba8ba-188b-4cf3-9df4-e2378e1d1aec.png)

![image](https://user-images.githubusercontent.com/9963310/147651821-80ea3838-e27c-4159-a7e7-055e9a2d271a.png)

![image](https://user-images.githubusercontent.com/9963310/147651600-3c01fbc2-7f4b-4cd9-8159-db47faf50bfb.png)
(images by @thehans)

## Background

The tension was not accounted for in the extra corner point. Which it turns out is not actually needed, as the arc already goes there all the way.

## Credits

Thanks to @thehans and @t-paul for singling the problem out!


