### PR TITLE
Add workflow to generate and publish STL artifact.

### DIFF
--- a/.github/workflows/build-stl.yml
+++ b/.github/workflows/build-stl.yml
@@ -4,11 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       play:
-        required: true
         type: number
         default: -0.05
       axle_play:
-        required: true
         type: number
         default: -0.02
 
@@ -21,16 +19,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build STL
+      - name: Update play Parameter
+        if: github.event.inputs.play
+        uses: jossef/action-set-json-field@v1
+        with:
+          file: print_params.json
+          field: parameterSets.feeder_print.play
+          value: ${{github.event.inputs.play}}
+      - name: Update axle_play Parameter
+        if: github.event.inputs.axle_play
+        uses: jossef/action-set-json-field@v1
+        with:
+          file: print_params.json
+          field: parameterSets.feeder_print.play
+          value: ${{github.event.inputs.axle_play}}
+      - name: Build PushPullFeeder STL
         uses: docker://openscad/openscad:2021.01
         with:
           entrypoint: openscad
-          args: /github/workspace/PushPullFeeder.scad -o /github/workspace/PushPullFeeder.stl
+          args: /github/workspace/PushPullFeeder.scad --enable=customizer -p /github/workspace/print_params.json -P feeder_print -o /github/workspace/TestPrint.stl
       - name: Build Test Print STL
         uses: docker://openscad/openscad:2021.01
         with:
           entrypoint: openscad
-          args: /github/workspace/PushPullFeeder.scad --enable=customizer -p /github/workspace/test_print.json -P test_print -o /github/workspace/TestPrint.stl
+          args: /github/workspace/PushPullFeeder.scad --enable=customizer -p /github/workspace/print_params.json -P test_print -o /github/workspace/TestPrint.stl
       - name: Generate PNG preview
         uses: docker://openscad/openscad:egl
         with:

--- a/.github/workflows/build-stl.yml
+++ b/.github/workflows/build-stl.yml
@@ -2,6 +2,16 @@ name: Build STL file
 
 on:
   workflow_dispatch:
+    inputs:
+      play:
+        required: true
+        type: number
+        default: -0.05
+      axle_play:
+        required: true
+        type: number
+        default: -0.02
+
   push:
     branches:
       - master
@@ -16,6 +26,11 @@ jobs:
         with:
           entrypoint: openscad
           args: /github/workspace/PushPullFeeder.scad -o /github/workspace/PushPullFeeder.stl
+      - name: Build Test Print STL
+        uses: docker://openscad/openscad:2021.01
+        with:
+          entrypoint: openscad
+          args: /github/workspace/PushPullFeeder.scad --enable=customizer -p /github/workspace/test_print.json -P test_print -o /github/workspace/TestPrint.stl
       - name: Generate PNG preview
         uses: docker://openscad/openscad:egl
         with:
@@ -26,5 +41,8 @@ jobs:
         with:
           name: PushPullFeeder
           path: |
+            README.md
+            LICENSE
             PushPullFeeder.stl
+            TestPrint.stl
             PushPullFeeder.png

--- a/.github/workflows/build-stl.yml
+++ b/.github/workflows/build-stl.yml
@@ -1,0 +1,30 @@
+name: Build STL file
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build STL
+        uses: docker://openscad/openscad:2021.01
+        with:
+          entrypoint: openscad
+          args: /github/workspace/PushPullFeeder.scad -o /github/workspace/PushPullFeeder.stl
+      - name: Generate PNG preview
+        uses: docker://openscad/openscad:egl
+        with:
+          entrypoint: openscad
+          args: /github/workspace/PushPullFeeder.scad -o /github/workspace/PushPullFeeder.png
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: PushPullFeeder
+          path: |
+            PushPullFeeder.stl
+            PushPullFeeder.png

--- a/print_params.json
+++ b/print_params.json
@@ -1,5 +1,20 @@
 {
     "parameterSets": {
+       "feeder_print": {
+            "make_base_plate": "true",
+            "make_blocking_spring": "true",
+            "make_friction_wheel": "true",
+            "make_handle_lock": "true",
+            "make_inset": "true",
+            "make_lever": "true",
+            "make_lever_actuator": "false",
+            "make_nozzle_adapter": "false",
+            "make_reel_counterpart": "true",
+            "make_spool_left": "true",
+            "make_spool_right": "true",
+            "make_tape_chute": "true",
+            "make_test_print": "false"
+       },
        "test_print": {
             "make_base_plate": "false",
             "make_blocking_spring": "false",
@@ -14,7 +29,7 @@
             "make_spool_right": "false",
             "make_tape_chute": "false",
             "make_test_print": "true"
-       }
+        }
     },
     "fileFormatVersion": "1"
 }

--- a/test_print.json
+++ b/test_print.json
@@ -1,0 +1,20 @@
+{
+    "parameterSets": {
+       "test_print": {
+            "make_base_plate": "false",
+            "make_blocking_spring": "false",
+            "make_friction_wheel": "false",
+            "make_handle_lock": "false",
+            "make_inset": "false",
+            "make_lever": "false",
+            "make_lever_actuator": "false",
+            "make_nozzle_adapter": "false",
+            "make_reel_counterpart": "false",
+            "make_spool_left": "false",
+            "make_spool_right": "false",
+            "make_tape_chute": "false",
+            "make_test_print": "true"
+       }
+    },
+    "fileFormatVersion": "1"
+}


### PR DESCRIPTION
This is a simple workflow to build the STL file and a PNG preview using the official OpenSCAD docker images.  They're uploaded as artifacts of the workflow action.  You can see the [output in my PushPullFeeder fork](https://github.com/james-conrad/PushPullFeeder/actions/runs/1816275445) if you're interested.

This was easier than installing OpenSCAD on my machine.